### PR TITLE
Fix documentation for v3.11.6

### DIFF
--- a/docs/api/api_docs.md
+++ b/docs/api/api_docs.md
@@ -1175,23 +1175,26 @@ The method is used to request user's certificates.
 |                       |                   |   | * ``authRSA`` – request for authentication RSA certificate, if available;                             |
 |                       |                   |   | * ``authECC`` – request for authentication ECC certificate, if available;                             |
 |                       |                   |   | * ``sign`` – request for default certificate for digital signing;                                     |
-|                       |                   |   | * ``signRSA`` – request for RSA certificate for digital signing, if available; signECC – request      |
-|                       |                   |   |   for ECC certificate for digital signing, if available;                                              |
+|                       |                   |   | * ``signRSA`` – request for RSA certificate for digital signing, if available;                        |
+|                       |                   |   | * ``signECC`` – request for ECC certificate for digital signing, if available;                        |
 |                       |                   |   | * ``both`` – request for both (authentication and digital signing) default certificates;              | 
 |                       |                   |   | * ``bothRSA`` – both RSA certificates; "bothECC" – both ECC certificates;                             |
-|                       |                   |   | * ``"none`` – none.                                                                                   |
+|                       |                   |   | * ``"none`` – none.                                                                                   |               
+                        |                   |   |                                                                                                       |
+                        |                   |   | In case the user only has RSA certificates but ECC certificates are requested or vice versa then      |
+                        |                   |   | SOAP error code 105 is returned                                                                       |
 +-----------------------+-------------------+---+-------------------------------------------------------------------------------------------------------+
 
 #### Response
 
 | **Parameter** | **Type** | **Description** |
 | --- | --- | --- |
-| AuthCertStatus | String | OK – the authentication certificate has not expired. Note that the certificate may still be inactive for other reasons (it may be revoked by its owner).REVOKED – certificate has expired. The application provider may additionally ask for definitive certificate status by using an OCSP service (for example using the "CheckCertificate" operation). |
-| SignCertStatus | String | OK – the signing certificate has not expired. Note that the certificate may still be inactive for other reasons (it may be revoked by its owner).REVOKED – certificate has expired. The application provider may additionally ask for definitive certificate status by using an OCSP service (for example using the "CheckCertificate" operation). |
+| AuthCertStatus | String | OK – the authentication certificate has not expired. The application provider may additionally ask for definitive certificate status by using an OCSP service (for example using the "CheckCertificate" operation). |
+| SignCertStatus | String | OK – the signing certificate has not expired. The application provider may additionally ask for definitive certificate status by using an OCSP service (for example using the "CheckCertificate" operation). |
 | AuthCertData | String | Authentication certificate in PEM form |
 | SignCertData | String | Digital signing certificate in PEM form |
 
-If the user does not possess Mobile-ID SIM, SOAP fault is returned in accordance with p 9.4.
+If the users certificates are expired or are marked as REVOKED or the user does not possess Mobile-ID SIM, SOAP fault is returned in accordance with p 9.4. See [SOAP Error messages](#soap-error-messages) with error codes 305, 302 and 301.
 
 
 
@@ -1519,6 +1522,7 @@ A new structure of error objects is being used in the responses of the methods M
 | 102 | Some of required input parameters are missing |
 | 103 | Client does not have access to external service, e.g. MSSP or SK validity confirmation service (OCSP response UNAUTHORIZED |
 | 104 | Client is not authorized to access service |
+| 105 | User don't have specified type of certificates |
 | 200 | General error of the service |
 | 201 | Missing user certificate |
 | 202 | Unable to verify certificate validity |

--- a/docs/api/api_docs.md
+++ b/docs/api/api_docs.md
@@ -1180,9 +1180,9 @@ The method is used to request user's certificates.
 |                       |                   |   | * ``both`` – request for both (authentication and digital signing) default certificates;              | 
 |                       |                   |   | * ``bothRSA`` – both RSA certificates; "bothECC" – both ECC certificates;                             |
 |                       |                   |   | * ``"none`` – none.                                                                                   |               
-                        |                   |   |                                                                                                       |
-                        |                   |   | In case the user only has RSA certificates but ECC certificates are requested or vice versa then      |
-                        |                   |   | SOAP error code 105 is returned                                                                       |
+|                       |                   |   |                                                                                                       |
+|                       |                   |   | In case the user only has RSA certificates but ECC certificates are requested or vice versa then      |
+|                       |                   |   | SOAP error code 105 is returned                                                                       |
 +-----------------------+-------------------+---+-------------------------------------------------------------------------------------------------------+
 
 #### Response

--- a/docs/api/api_docs.md
+++ b/docs/api/api_docs.md
@@ -1138,8 +1138,7 @@ The method is used to query status information when using asynchClientServer mob
 |                       |                   | * ``REVOKED_CERTIFICATE`` – certificate revoked                                                           |
 |                       |                   | * ``INTERNAL_ERROR`` – technical error.                                                                   |
 +-----------------------+-------------------+-----------------------------------------------------------------------------------------------------------+
-| Signature             | String            | Signature value in PKCS#1 container in BASE64 encoding. Can be either an RSA or ECDSA signature,          |
-|                       |                   | depending on the signer's certificate returned with the signature block.                                  |
+| Signature             | String            | The resulting ``<Signature>`` block in  pure XML.                                                         |
 +-----------------------+-------------------+-----------------------------------------------------------------------------------------------------------+
 
 Is the value in Status field is not OUTSTANDING\_TRANSACTION then active session is closed after this request.

--- a/docs/api/api_docs.md
+++ b/docs/api/api_docs.md
@@ -850,7 +850,7 @@ Potential error-messages:
 
 ## GetNotary
 
-The request returns the validity confirmation of the certain signature.
+The request returns the certificate validity confirmation of the certain signature.
 
 #### Request
 

--- a/docs/api/api_docs.md
+++ b/docs/api/api_docs.md
@@ -1533,8 +1533,6 @@ A new structure of error objects is being used in the responses of the methods M
 | 303 | Certificate is not activated or/and status of the certificate is unknown (OCSP said: UNKNOWN) |
 | 304 | Certificates is suspended |
 | 305 | Certificate is expired |
-| 413 | Incoming message exceeds permitted volume limit. |
-| 503 | The number of simultaneous requests of the service has been exceeded. |
 
 #### Example 1 of the service error message
 
@@ -1571,6 +1569,16 @@ Several errors were identified in the request (the second version service, new s
    </detail>
 </SOAP-ENV:Fault>
 ```
+#### Non Soap Errors
+
+
+The service can also return plain HTTP errors in certain cases
+
+| **Error Code** | **Explanation** |
+| --- | --- |
+| 413 | Incoming message exceeds permitted volume limit. |
+| 503 | The number of simultaneous requests of the service has been exceeded. |
+
 
 ## Container validation
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,9 @@ extra_javascript:
 markdown_extensions:
   - grid_tables
 extra:
-  last_updated: '09.03.2018'
-  service_version: '3.11.4'
-  document_version: '3.11.4'
+  last_updated: '27.06.2018'
+  service_version: '3.11.6'
+  document_version: '3.11.6'
 pages:
   - Overview: index.md      
   - API Docs: api/api_docs.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ extra_javascript:
 markdown_extensions:
   - grid_tables
 extra:
-  last_updated: '27.06.2018'
+  last_updated: '28.06.2018'
   service_version: '3.11.6'
   document_version: '3.11.6'
 pages:


### PR DESCRIPTION
* Http error codes removed from List of soap errors into a separate section
* Fix GetNotary service method explanation
* Fix GetMobileCreateSignatureStatus response documentation regarding returned signature format